### PR TITLE
Enable deployment using CodeDeploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 
 .build-harness
 build-harness
+
+*.terraform.lock.hcl

--- a/main.tf
+++ b/main.tf
@@ -382,7 +382,9 @@ resource "aws_codepipeline" "default" {
     aws_iam_role_policy_attachment.s3,
     aws_iam_role_policy_attachment.codebuild,
     aws_iam_role_policy_attachment.codebuild_s3,
-    aws_iam_role_policy_attachment.codedeploy
+    aws_iam_role_policy_attachment.codedeploy,
+    aws_iam_role_policy_attachment.codebuild_ecr,
+    aws_iam_role_policy_attachment.codedeploy_role
   ]
 
   stage {
@@ -478,7 +480,7 @@ resource "aws_codepipeline" "default" {
 
         configuration = {
           ApplicationName                = join("", module.codedeploy.*.name)
-          DeploymentGroupName            = join("", module.codedeploy.*.deployment_config_name)
+          DeploymentGroupName            = join("", module.codedeploy.*.group_name)
           Image1ArtifactName             = "task"
           Image1ContainerName            = "IMAGE1_NAME"
           AppSpecTemplateArtifact        = "task"
@@ -512,7 +514,8 @@ resource "aws_codepipeline" "bitbucket" {
     aws_iam_role_policy_attachment.s3,
     aws_iam_role_policy_attachment.codebuild,
     aws_iam_role_policy_attachment.codebuild_s3,
-    aws_iam_role_policy_attachment.codestar
+    aws_iam_role_policy_attachment.codestar,
+    aws_iam_role_policy_attachment.codedeploy
   ]
 
   stage {

--- a/main.tf
+++ b/main.tf
@@ -288,7 +288,6 @@ resource "aws_iam_role_policy_attachment" "codebuild_ecr" {
   policy_arn = join("", aws_iam_policy.ecr.*.arn)
 }
 
-
 ## CodeDeploy Module ###
 data "aws_iam_policy_document" "codedeploy" {
   statement {

--- a/main.tf
+++ b/main.tf
@@ -260,7 +260,7 @@ data "aws_iam_policy_document" "ecr" {
     ]
 
     resources = [
-      data.aws_ecr_repository.default.arn
+      join("", data.aws_ecr_repository.default.*.arn)
     ]
 
     effect = "Allow"
@@ -277,13 +277,13 @@ module "codepipeline_ecr_policy_label" {
 }
 
 resource "aws_iam_policy" "ecr" {
-  count  = module.this.enabled && var.image_repo_name ? 1 : 0
+  count  = module.this.enabled && var.image_repo_name != "" ? 1 : 0
   name   = module.codepipeline_ecr_policy_label.id
   policy = join("", data.aws_iam_policy_document.ecr.*.json)
 }
 
 resource "aws_iam_role_policy_attachment" "codebuild_ecr" {
-  count      = module.this.enabled && var.image_repo_name ? 1 : 0
+  count      = module.this.enabled && var.image_repo_name != "" ? 1 : 0
   role       = module.codebuild.role_id
   policy_arn = join("", aws_iam_policy.ecr.*.arn)
 }
@@ -325,7 +325,7 @@ module "codedeploy_label" {
 resource "aws_iam_policy" "codedeploy" {
   count  = local.codedeploy_count
   name   = module.codedeploy_label.id
-  policy = data.aws_iam_policy_document.codedeploy.json
+  policy = join("", data.aws_iam_policy_document.codedeploy.*.json)
 }
 
 resource "aws_iam_role_policy_attachment" "codedeploy" {

--- a/main.tf
+++ b/main.tf
@@ -245,7 +245,7 @@ resource "aws_iam_role_policy_attachment" "codebuild_s3" {
 
 data "aws_ecr_repository" "default" {
   count = module.this.enabled && var.image_repo_name != "" ? 1 : 0
-  name  = var.image_repo_name
+  name  = element(split("/", var.image_repo_name), length(split("/", var.image_repo_name)) - 1)
 }
 
 data "aws_iam_policy_document" "ecr" {

--- a/main.tf
+++ b/main.tf
@@ -345,8 +345,7 @@ data "aws_partition" "current" {
 }
 
 module "codedeploy" {
-  source  = "cloudposse/code-deploy/aws"
-  version = "0.2.3"
+  source = "git::https://github.com/gudangada/terraform-aws-code-deploy"
 
   count                              = local.codedeploy_count
   minimum_healthy_hosts              = var.minimum_healthy_hosts

--- a/main.tf
+++ b/main.tf
@@ -304,7 +304,7 @@ data "aws_iam_policy_document" "codedeploy" {
     ]
 
     resources = [
-      "arn:aws:codedeploy:${local.region}:${local.aws_account_id}:deploymentgroup:${local.codedeploy_app_name}/${local.codedeploy_config_name}",
+      "arn:aws:codedeploy:${local.region}:${local.aws_account_id}:deploymentgroup:${local.codedeploy_app_name}/${local.codedeploy_group_name}",
       "arn:aws:codedeploy:${local.region}:${local.aws_account_id}:application:${local.codedeploy_app_name}",
       "arn:aws:codedeploy:${local.region}:${local.aws_account_id}:deploymentconfig:${local.codedeploy_config_name}"
     ]
@@ -591,6 +591,7 @@ locals {
   codedeploy_count       = module.this.enabled && var.use_codedeploy_for_deployment ? 1 : 0
   codedeploy_app_name    = join("", module.codedeploy.*.name)
   codedeploy_config_name = join("", module.codedeploy.*.deployment_config_name)
+  codedeploy_group_name  = join("", module.codedeploy.*.group_name)
 
   webhook_secret = join("", random_string.webhook_secret.*.result)
   webhook_url    = join("", aws_codepipeline_webhook.webhook.*.url)

--- a/outputs.tf
+++ b/outputs.tf
@@ -67,3 +67,28 @@ output "codepipeline_resource" {
   description = "CodePipeline resource"
   value       = local.codepipeline_resource
 }
+
+output "id" {
+  description = "The application ID."
+  value       = try(module.codebuild.id, null)
+}
+
+output "name" {
+  description = "The application's name."
+  value       = try(module.codebuild, null)
+}
+
+output "group_id" {
+  description = "The application group ID."
+  value       = try(module.codebuild.group_id, null)
+}
+
+output "deployment_config_name" {
+  description = "The deployment group's config name."
+  value       = try(module.codebuild.deployment_config_name, null)
+}
+
+output "deployment_config_id" {
+  description = "The deployment config ID."
+  value       = try(module.codebuild.deployment_config_id, null)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -299,21 +299,6 @@ variable "deployment_style" {
   DOC
 }
 
-variable "ecs_service" {
-  type = list(object({
-    cluster_name = string
-    service_name = string
-  }))
-  default     = null
-  description = <<-DOC
-    Configuration block(s) of the ECS services for a deployment group.
-    cluster_name:
-      The name of the ECS cluster. 
-    service_name:
-      The name of the ECS service.
-  DOC
-}
-
 variable "load_balancer_info" {
   type        = map(any)
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -211,16 +211,11 @@ variable "disable_approval_before_build" {
   description = "Boolean to enable or disable manual approval before build"
 }
 
+### CodeDeploy ###
 variable "use_codedeploy_for_deploy_stage" {
   type        = bool
   default     = false
   description = "Boolean to enable codepipeline to use CodeDeploy as deployment provider"
-}
-
-variable "compute_platform" {
-  type        = string
-  default     = "ECS"
-  description = "The compute platform can either be `ECS`, `Lambda`, or `Server`"
 }
 
 variable "minimum_healthy_hosts" {
@@ -256,18 +251,6 @@ variable "traffic_routing_config" {
   DOC
 }
 
-variable "create_default_service_role" {
-  type        = bool
-  default     = true
-  description = "Whether to create default IAM role ARN that allows deployments."
-}
-
-variable "service_role_arn" {
-  type        = string
-  default     = null
-  description = "The service IAM role ARN that allows deployments."
-}
-
 variable "create_default_sns_topic" {
   type        = bool
   default     = true
@@ -278,12 +261,6 @@ variable "sns_topic_arn" {
   type        = string
   default     = null
   description = "The ARN of the SNS topic through which notifications are sent."
-}
-
-variable "autoscaling_groups" {
-  type        = list(string)
-  description = "A list of Autoscaling Groups associated with the deployment group."
-  default     = []
 }
 
 variable "alarm_configuration" {
@@ -334,44 +311,6 @@ variable "deployment_style" {
   DOC
 }
 
-variable "ec2_tag_filter" {
-  type = set(object({
-    key   = string
-    type  = string
-    value = string
-  }))
-  default     = []
-  description = <<-DOC
-    The Amazon EC2 tags on which to filter. The deployment group includes EC2 instances with any of the specified tags.
-    Cannot be used in the same call as ec2TagSet.
-  DOC
-}
-
-variable "ec2_tag_set" {
-  type = set(object(
-    {
-      ec2_tag_filter = set(object(
-        {
-          key   = string
-          type  = string
-          value = string
-        }
-      ))
-    }
-  ))
-  default     = []
-  description = <<-DOC
-    A list of sets of tag filters. If multiple tag groups are specified,
-    any instance that matches to at least one tag filter of every tag group is selected.
-    key:
-      The key of the tag filter.
-    type:
-      The type of the tag filter, either `KEY_ONLY`, `VALUE_ONLY`, or `KEY_AND_VALUE`.
-    value:
-      The value of the tag filter.
-  DOC
-}
-
 variable "ecs_service" {
   type = list(object({
     cluster_name = string
@@ -395,16 +334,4 @@ variable "load_balancer_info" {
     see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_deployment_group#load_balancer_info
   DOC
 }
-
-variable "trigger_events" {
-  type        = list(string)
-  default     = ["DeploymentFailure"]
-  description = <<-DOC
-    The event type or types for which notifications are triggered. 
-    Some values that are supported: 
-      `DeploymentStart`, `DeploymentSuccess`, `DeploymentFailure`, `DeploymentStop`, 
-      `DeploymentRollback`, `InstanceStart`, `InstanceSuccess`, `InstanceFailure`. 
-    See the CodeDeploy documentation for all possible values.
-    http://docs.aws.amazon.com/codedeploy/latest/userguide/monitoring-sns-event-notifications-create-trigger.html 
-  DOC
-}
+### CodeDeploy ###

--- a/variables.tf
+++ b/variables.tf
@@ -212,7 +212,7 @@ variable "disable_approval_before_build" {
 }
 
 ### CodeDeploy ###
-variable "use_codedeploy_for_deploy_stage" {
+variable "use_codedeploy_for_deployment" {
   type        = bool
   default     = false
   description = "Boolean to enable codepipeline to use CodeDeploy as deployment provider"

--- a/variables.tf
+++ b/variables.tf
@@ -204,3 +204,207 @@ variable "codebuild_vpc_config" {
   default     = {}
   description = "Configuration for the builds to run inside a VPC."
 }
+
+variable "disable_approval_before_build" {
+  type        = bool
+  default     = false
+  description = "Boolean to enable or disable manual approval before build"
+}
+
+variable "use_codedeploy_for_deploy_stage" {
+  type        = bool
+  default     = false
+  description = "Boolean to enable codepipeline to use CodeDeploy as deployment provider"
+}
+
+variable "compute_platform" {
+  type        = string
+  default     = "ECS"
+  description = "The compute platform can either be `ECS`, `Lambda`, or `Server`"
+}
+
+variable "minimum_healthy_hosts" {
+  type = object({
+    type  = string
+    value = number
+  })
+  default     = null
+  description = <<-DOC
+    type:
+      The type can either be `FLEET_PERCENT` or `HOST_COUNT`.
+    value:
+      The value when the type is `FLEET_PERCENT` represents the minimum number of healthy instances 
+      as a percentage of the total number of instances in the deployment.
+      When the type is `HOST_COUNT`, the value represents the minimum number of healthy instances as an absolute value.
+  DOC
+}
+
+variable "traffic_routing_config" {
+  type = object({
+    type       = string
+    interval   = number
+    percentage = number
+  })
+  default     = null
+  description = <<-DOC
+    type:
+      Type of traffic routing config. One of `TimeBasedCanary`, `TimeBasedLinear`, `AllAtOnce`.
+    interval:
+      The number of minutes between the first and second traffic shifts of a deployment.
+    percentage:
+      The percentage of traffic to shift in the first increment of a deployment.
+  DOC
+}
+
+variable "create_default_service_role" {
+  type        = bool
+  default     = true
+  description = "Whether to create default IAM role ARN that allows deployments."
+}
+
+variable "service_role_arn" {
+  type        = string
+  default     = null
+  description = "The service IAM role ARN that allows deployments."
+}
+
+variable "create_default_sns_topic" {
+  type        = bool
+  default     = true
+  description = "Whether to create default SNS topic through which notifications are sent."
+}
+
+variable "sns_topic_arn" {
+  type        = string
+  default     = null
+  description = "The ARN of the SNS topic through which notifications are sent."
+}
+
+variable "autoscaling_groups" {
+  type        = list(string)
+  description = "A list of Autoscaling Groups associated with the deployment group."
+  default     = []
+}
+
+variable "alarm_configuration" {
+  type = object({
+    alarms                    = list(string)
+    ignore_poll_alarm_failure = bool
+  })
+  default     = null
+  description = <<-DOC
+     Configuration of deployment to stop when a CloudWatch alarm detects that a metric has fallen below or exceeded a defined threshold.
+      alarms:
+        A list of alarms configured for the deployment group.
+      ignore_poll_alarm_failure:
+        Indicates whether a deployment should continue if information about the current state of alarms cannot be retrieved from CloudWatch.
+  DOC
+}
+
+variable "auto_rollback_configuration_events" {
+  type        = string
+  default     = "DEPLOYMENT_FAILURE"
+  description = "The event type or types that trigger a rollback. Supported types are `DEPLOYMENT_FAILURE` and `DEPLOYMENT_STOP_ON_ALARM`."
+}
+
+variable "blue_green_deployment_config" {
+  type        = any
+  default     = null
+  description = <<-DOC
+    Configuration block of the blue/green deployment options for a deployment group, 
+    see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_deployment_group#blue_green_deployment_config
+  DOC
+}
+
+variable "deployment_style" {
+  type = object({
+    deployment_option = string
+    deployment_type   = string
+  })
+  default     = null
+  description = <<-DOC
+    Configuration of the type of deployment, either in-place or blue/green, 
+    you want to run and whether to route deployment traffic behind a load balancer.
+    deployment_option:
+      Indicates whether to route deployment traffic behind a load balancer. 
+      Possible values: `WITH_TRAFFIC_CONTROL`, `WITHOUT_TRAFFIC_CONTROL`.
+    deployment_type:
+      Indicates whether to run an in-place deployment or a blue/green deployment.
+      Possible values: `IN_PLACE`, `BLUE_GREEN`.
+  DOC
+}
+
+variable "ec2_tag_filter" {
+  type = set(object({
+    key   = string
+    type  = string
+    value = string
+  }))
+  default     = []
+  description = <<-DOC
+    The Amazon EC2 tags on which to filter. The deployment group includes EC2 instances with any of the specified tags.
+    Cannot be used in the same call as ec2TagSet.
+  DOC
+}
+
+variable "ec2_tag_set" {
+  type = set(object(
+    {
+      ec2_tag_filter = set(object(
+        {
+          key   = string
+          type  = string
+          value = string
+        }
+      ))
+    }
+  ))
+  default     = []
+  description = <<-DOC
+    A list of sets of tag filters. If multiple tag groups are specified,
+    any instance that matches to at least one tag filter of every tag group is selected.
+    key:
+      The key of the tag filter.
+    type:
+      The type of the tag filter, either `KEY_ONLY`, `VALUE_ONLY`, or `KEY_AND_VALUE`.
+    value:
+      The value of the tag filter.
+  DOC
+}
+
+variable "ecs_service" {
+  type = list(object({
+    cluster_name = string
+    service_name = string
+  }))
+  default     = null
+  description = <<-DOC
+    Configuration block(s) of the ECS services for a deployment group.
+    cluster_name:
+      The name of the ECS cluster. 
+    service_name:
+      The name of the ECS service.
+  DOC
+}
+
+variable "load_balancer_info" {
+  type        = map(any)
+  default     = null
+  description = <<-DOC
+    Single configuration block of the load balancer to use in a blue/green deployment, 
+    see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codedeploy_deployment_group#load_balancer_info
+  DOC
+}
+
+variable "trigger_events" {
+  type        = list(string)
+  default     = ["DeploymentFailure"]
+  description = <<-DOC
+    The event type or types for which notifications are triggered. 
+    Some values that are supported: 
+      `DeploymentStart`, `DeploymentSuccess`, `DeploymentFailure`, `DeploymentStop`, 
+      `DeploymentRollback`, `InstanceStart`, `InstanceSuccess`, `InstanceFailure`. 
+    See the CodeDeploy documentation for all possible values.
+    http://docs.aws.amazon.com/codedeploy/latest/userguide/monitoring-sns-event-notifications-create-trigger.html 
+  DOC
+}

--- a/variables.tf
+++ b/variables.tf
@@ -251,18 +251,6 @@ variable "traffic_routing_config" {
   DOC
 }
 
-variable "create_default_sns_topic" {
-  type        = bool
-  default     = true
-  description = "Whether to create default SNS topic through which notifications are sent."
-}
-
-variable "sns_topic_arn" {
-  type        = string
-  default     = null
-  description = "The ARN of the SNS topic through which notifications are sent."
-}
-
 variable "alarm_configuration" {
   type = object({
     alarms                    = list(string)


### PR DESCRIPTION
Using CodeDeploy as a deployment provider, we can easily roll back to any revision. These changes are also backward compatible, tested by planning from the example module.

Testing:
- [x] Backward compatible: Planning the example module without any modification
- [x] Working correctly: Tested in AWS playground

![image](https://user-images.githubusercontent.com/5100951/169563428-e21be1ed-9042-4d22-92e8-5b0a4c11d7cf.png)
